### PR TITLE
Update W08

### DIFF
--- a/data/companies/2008.winter.yml
+++ b/data/companies/2008.winter.yml
@@ -37,6 +37,7 @@
   name: Insoshi
   url: http://insoshi.com
   description: Insoshi is an open-source open networking platform.
+  status: Dead
 -
   name: Joberator
   url: http://joberator.com


### PR DESCRIPTION
From the Founder's LinkedIn:

Company Name: Insoshi
Dates Employed: Jan 2008 – Mar 2009  Employment Duration1 yr 3 mos
Insoshi was a social networking platform. We were backed by Y Combinator, a top seed-stage venture capital firm.

The website is dead too: insoshi.com.