### PR TITLE
Update cover link to https://cover.com

### DIFF
--- a/data/companies/fellowship.v1.yml
+++ b/data/companies/fellowship.v1.yml
@@ -70,7 +70,7 @@
   description: Connect customers with the right products & services
 -
   name: Cover
-  url: http://www.usecover.com
+  url: https://cover.com
   description: Get insurance by taking a photo
 -
   name: Clearbanc


### PR DESCRIPTION
Cover is using https://cover.com as their main domain now (previously usecover.com).