### PR TITLE
Chartio acquired by Atlassian

### DIFF
--- a/companies/2010.summer.txt
+++ b/companies/2010.summer.txt
@@ -23,6 +23,8 @@ Brushes
 Chart.io
   https://chartio.com
   Analytics for everyone. A platform for everyone to explore and visualize data
+  status: exited
+  exit: Acquired by Atlassian in Feb 2021.
 
 Crowdbooster
   http://crowdbooster.com


### PR DESCRIPTION
Source: https://chartio.com/blog/atlassian/